### PR TITLE
Adjust build scripts to avoid workspace flag usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "shared"
   ],
   "scripts": {
-    "build": "npm run build --workspace=client && npm run build --workspace=server",
-    "dev": "npm run dev --workspace=server",
-    "db:push": "npm run db:push --workspace=server",
-    "db:studio": "npm run db:studio --workspace=server"
+    "build": "npm --prefix client run build && npm --prefix server run build",
+    "dev": "npm --prefix server run dev",
+    "db:push": "npm --prefix server run db:push",
+    "db:studio": "npm --prefix server run db:studio"
   }
 }


### PR DESCRIPTION
## Summary
- replace root npm scripts to use the --prefix flag instead of the workspace selector
- prevent deployment failures in environments that do not expose npm workspace commands

## Testing
- npm install *(fails in this environment with `Unsupported URL Type "workspace:"` but build scripts updated as described)*

------
https://chatgpt.com/codex/tasks/task_e_68e276364b4c833293aa81a3967bddb7