### PR TITLE
Add production fallback route for SPA navigation

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,6 +27,20 @@ app.use(express.static(distPath));
 
 registerRoutes(app);
 
+if (process.env.NODE_ENV === "production") {
+  app.get("*", (req, res, next) => {
+    if (req.path.startsWith("/api") || req.path.startsWith("/objects")) {
+      return next();
+    }
+
+    res.sendFile(path.join(distPath, "index.html"), (error) => {
+      if (error) {
+        next(error);
+      }
+    });
+  });
+}
+
 // Basic error handler
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {


### PR DESCRIPTION
## Summary
- add a production-only catch-all route that serves the built index.html for non-API/object requests
- ensure unmatched client routes render the SPA shell during production deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e28838d064833281e59e20ce552a88