### PR TITLE
Handle NODE_ENV defaults in production

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,9 @@ import { registerVite } from "./vite";
 
 const app = express();
 
+const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase() ?? "production";
+const isProduction = nodeEnv !== "development";
+
 app.use(cors({ origin: process.env.CLIENT_ORIGIN ?? true, credentials: true }));
 app.use(morgan("dev"));
 
@@ -27,7 +30,7 @@ app.use(express.static(distPath));
 
 registerRoutes(app);
 
-if (process.env.NODE_ENV === "production") {
+if (isProduction) {
   app.get("*", (req, res, next) => {
     if (req.path.startsWith("/api") || req.path.startsWith("/objects")) {
       return next();

--- a/server/src/vite.ts
+++ b/server/src/vite.ts
@@ -2,7 +2,8 @@ import type { Express } from "express";
 import path from "node:path";
 
 export async function registerVite(app: Express) {
-  if (process.env.NODE_ENV === "production") {
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase() ?? "production";
+  if (nodeEnv !== "development") {
     return;
   }
 


### PR DESCRIPTION
## Summary
- treat any non-development NODE_ENV (including undefined) as production for server routing
- guard Vite dev middleware to only load during development to avoid missing dependency errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e29c8ac28483329f91f94b66be7f10